### PR TITLE
Add .gitattributes to treat HolyC as C

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Highlight HolyC as C
+*.HC linguist-language=C

--- a/Env.HC
+++ b/Env.HC
@@ -1,7 +1,7 @@
 #ifndef ENV_HC
 #define ENV_HC
 
-// An environment mapping strings to Malvals
+// An environment mapping Strings to Malvals
 
 #include "GCCommon.HC"
 #include "Hashmap.HC"


### PR DESCRIPTION
This enables GitHub syntax highlighting on the HolyC files as if they were regular C.